### PR TITLE
style: Added rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+edition="2021"
+reorder_imports = true


### PR DESCRIPTION
Updated example to use the same `rustfmt.toml` from the base `shuttle` repo.