### PR TITLE
chore: bump salvo

### DIFF
--- a/salvo/hello-world/Cargo.toml
+++ b/salvo/hello-world/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-salvo = "0.37.5"
+salvo = "0.41.0"
 shuttle-salvo = { version = "0.16.0" }
 shuttle-runtime = { version = "0.16.0" }
 tokio = { version = "1.26.0" }


### PR DESCRIPTION
Bumps salvo, this should be merged before the 0.17 release and merged into main before the examples submodule in shuttle is updated with 0.17 examples.

Tested by running locally against the updated shuttle-salvo service.