### PR TITLE
fix: make Stripe payment price a secret instead of hardcoding

### DIFF
--- a/fullstack-templates/saas/backend/src/main.rs
+++ b/fullstack-templates/saas/backend/src/main.rs
@@ -23,6 +23,7 @@ use router::create_api_router;
 pub struct AppState {
     pub postgres: PgPool,
     pub stripe_key: String,
+    pub stripe_sub_price: String,
     pub mailgun_key: String,
     pub mailgun_url: String,
     pub domain: String,
@@ -51,6 +52,7 @@ async fn axum(
     let state = AppState {
         postgres,
         stripe_key,
+        stripe_sub_price,
         mailgun_key,
         mailgun_url,
         domain,
@@ -79,6 +81,10 @@ fn grab_secrets(secrets: shuttle_secrets::SecretStore) -> (String, String, Strin
         .get("STRIPE_KEY")
         .unwrap_or_else(|| "None".to_string());
 
+    let stripe_sub_price = secrets
+        .get("STRIPE_SUB_PRICE")
+        .unwrap_or_else(|| "None".to_string());
+
     let mailgun_key = secrets
         .get("MAILGUN_KEY")
         .unwrap_or_else(|| "None".to_string());
@@ -91,5 +97,5 @@ fn grab_secrets(secrets: shuttle_secrets::SecretStore) -> (String, String, Strin
         .get("DOMAIN_URL")
         .unwrap_or_else(|| "None".to_string());
 
-    (stripe_key, mailgun_key, mailgun_url, domain)
+    (stripe_key, stripe_sub_price, mailgun_key, mailgun_url, domain)
 }

--- a/fullstack-templates/saas/backend/src/payments.rs
+++ b/fullstack-templates/saas/backend/src/payments.rs
@@ -73,7 +73,7 @@ pub async fn create_checkout(
         pm
     };
 
-    let mut params = create_checkout_params(customer.id);
+    let mut params = create_checkout_params(customer.id, state.stripe_sub_price);
 
     params.default_payment_method = Some(&payment_method.id);
 
@@ -84,10 +84,10 @@ pub async fn create_checkout(
     Ok(StatusCode::OK)
 }
 
-fn create_checkout_params(customer_id: CustomerId) -> CreateSubscription<'static> {
+fn create_checkout_params(customer_id: CustomerId, price: String) -> CreateSubscription<'static> {
     let mut params = CreateSubscription::new(customer_id);
     params.items = Some(vec![CreateSubscriptionItems {
-        price: Some("price_1Mxby1I1KxxteAOMLAMeWgQD".to_string()),
+        price: Some(price),
         ..Default::default()
     }]);
     params.expand = &["items", "items.data.price.product", "schedule"];


### PR DESCRIPTION
* Moves the value of the Stripe subscription price object string to Secrets.toml instead of hardcoding it.

I meant to make this a secret at some point but completely forgot. 

This should allow users to just set it in their `Secrets.toml` file instead of needing to hardcode it in. Users will be able to extend this as necessary through just adding more prices and having more routes as required.