### PR TITLE
feat: Add an axum/with-state example using updated generic AxumService

### DIFF
--- a/axum/with-state/Cargo.toml
+++ b/axum/with-state/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 
 [dependencies]
 axum = "0.6.10"
-shuttle-axum = { version = "0.17.0" }
-shuttle-runtime = { version = "0.17.0" }
+shuttle-axum = { version = "0.18.0" }
+shuttle-runtime = { version = "0.18.0" }
 tokio = { version = "1.26.0" }

--- a/axum/with-state/Cargo.toml
+++ b/axum/with-state/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 
 [dependencies]
 axum = "0.6.10"
-shuttle-axum = { version = "0.16.0", path = "../../../services/shuttle-axum" }
-shuttle-runtime = { version = "0.16.0", path = "../../../runtime" }
+shuttle-axum = { version = "0.17.0" }
+shuttle-runtime = { version = "0.17.0" }
 tokio = { version = "1.26.0" }

--- a/axum/with-state/Cargo.toml
+++ b/axum/with-state/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "with-state"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+axum = "0.6.10"
+shuttle-axum = { version = "0.16.0", path = "../../../services/shuttle-axum" }
+shuttle-runtime = { version = "0.16.0", path = "../../../runtime" }
+tokio = { version = "1.26.0" }

--- a/axum/with-state/src/main.rs
+++ b/axum/with-state/src/main.rs
@@ -1,0 +1,23 @@
+use std::sync::Arc;
+
+use axum::{extract::State, response::IntoResponse, routing::get, Router};
+
+async fn hello_world(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    state.name
+}
+
+#[derive(Clone)]
+struct AppState {
+    name: &'static str,
+}
+
+#[shuttle_runtime::main]
+async fn axum() -> shuttle_axum::ShuttleAxum {
+    let state = Arc::new(AppState {
+        name: "Hello, world!",
+    });
+
+    let router = Router::new().route("/", get(hello_world)).with_state(state);
+
+    Ok(router.into())
+}

--- a/axum/with-state/src/main.rs
+++ b/axum/with-state/src/main.rs
@@ -3,18 +3,18 @@ use std::sync::Arc;
 use axum::{extract::State, response::IntoResponse, routing::get, Router};
 
 async fn hello_world(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    state.name
+    state.msg
 }
 
 #[derive(Clone)]
 struct AppState {
-    name: &'static str,
+    msg: &'static str,
 }
 
 #[shuttle_runtime::main]
 async fn axum() -> shuttle_axum::ShuttleAxum {
     let state = Arc::new(AppState {
-        name: "Hello, world!",
+        msg: "Hello, world!",
     });
 
     let router = Router::new().route("/", get(hello_world)).with_state(state);


### PR DESCRIPTION
Adds a `axum/with-state` example project showing off usage of `axum::State` with an updated `AxumService` from [this PR](https://github.com/shuttle-hq/shuttle/pull/924).

~Draft for now as I'm waiting for the other PR to be merged to remove local dependencies.~ Done.