### PR TITLE
feat: Add "none" example.

### DIFF
--- a/none/Cargo.toml
+++ b/none/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "none"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+shuttle-runtime = "0.17.0"

--- a/none/src/main.rs
+++ b/none/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}


### PR DESCRIPTION
Created by running `cargo shuttle init` and selecting the "none" option.

Will be used by https://github.com/shuttle-hq/shuttle/issues/867. Specifically to replace this `todo`: https://github.com/shuttle-hq/shuttle/pull/888/files#r1187751954