### PR TITLE
feat: examples for injecting a custom tracing layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Thruster | [postgres](./thruster/postgres/) | TODO app with a Postgres DB | `car
 Tide | [hello-world](./tide/hello-world/) | Hello World | `cargo shuttle init --template tide`
 Tide | [postgres](./tide/postgres/) | TODO app with a Postgres DB | `cargo shuttle init --from shuttle-hq/shuttle-examples --subfolder tide/postgres`
 Tower | [hello-world](./tower/hello-world/) | Hello World | `cargo shuttle init --template tower`
+Tracing | [custom-layer](./tracing/custom-layer/) | Custom tracing layer | `cargo shuttle init --template --from shuttle-hq/shuttle-examples --subfolder tracing/custom-layer`
+Tracing | [axum-logs-endpoint](./tracing/axum-logs-endpoint/) | Expose application logs with Axum | `cargo shuttle init --from shuttle-hq/shuttle-examples --subfolder tracing/axum-logs-endpoint`
 Warp | [hello-world](./warp/hello-world/) | Hello World | `cargo shuttle init --template warp`
 *Custom Service* | [none](./custom-service/none/) | Empty service - A barebones implementation of Shuttle Service trait that does nothing | `cargo shuttle init --template none`
 *Custom Service* | [request-scheduler](./custom-service/request-scheduler/) | A custom *Request Scheduler* service | `cargo shuttle init --from shuttle-hq/shuttle-examples --subfolder custom-service/request-scheduler`

--- a/tracing/axum-logs-endpoint/Cargo.toml
+++ b/tracing/axum-logs-endpoint/Cargo.toml
@@ -8,7 +8,6 @@ tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["json"] }
 tokio = "1.28.2"
 
-# shuttle-runtime = "0.18.0"
 shuttle-runtime = { path = "../../../runtime" }
 shuttle-axum = { path = "../../../services/shuttle-axum" }
 axum = "0.6.19"

--- a/tracing/axum-logs-endpoint/Cargo.toml
+++ b/tracing/axum-logs-endpoint/Cargo.toml
@@ -9,8 +9,8 @@ tracing-subscriber = { version = "0.3.17", features = ["json"] }
 tokio = "1.28.2"
 
 # shuttle-runtime = "0.18.0"
-shuttle-runtime = { path = "../../../../shuttle.git/custom-tracing-layer/runtime" }
-shuttle-axum = { path = "../../../../shuttle.git/custom-tracing-layer/services/shuttle-axum" }
+shuttle-runtime = { path = "../../../runtime" }
+shuttle-axum = { path = "../../../services/shuttle-axum" }
 axum = "0.6.19"
 axum-error = "0.2.0"
 serde = { version = "1.0.180", features = ["derive"] }

--- a/tracing/axum-logs-endpoint/Cargo.toml
+++ b/tracing/axum-logs-endpoint/Cargo.toml
@@ -8,10 +8,10 @@ tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["json"] }
 tokio = "1.28.2"
 
-shuttle-runtime = { path = "../../../runtime" }
-shuttle-axum = { path = "../../../services/shuttle-axum" }
 axum = "0.6.19"
 axum-error = "0.2.0"
 serde = { version = "1.0.180", features = ["derive"] }
 serde_json = "1.0.104"
+shuttle-runtime = "0.23.0"
+shuttle-axum = "0.23.0"
 lazy_static = "1.4.0"

--- a/tracing/axum-logs-endpoint/Cargo.toml
+++ b/tracing/axum-logs-endpoint/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "axum-logs-endpoint"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.17", features = ["json"] }
+tokio = "1.28.2"
+
+# shuttle-runtime = "0.18.0"
+shuttle-runtime = { path = "../../../../shuttle.git/custom-tracing-layer/runtime" }
+shuttle-axum = { path = "../../../../shuttle.git/custom-tracing-layer/services/shuttle-axum" }
+axum = "0.6.19"
+axum-error = "0.2.0"
+serde = { version = "1.0.180", features = ["derive"] }
+serde_json = "1.0.104"
+lazy_static = "1.4.0"

--- a/tracing/axum-logs-endpoint/Shuttle.toml
+++ b/tracing/axum-logs-endpoint/Shuttle.toml
@@ -1,0 +1,1 @@
+name = "axum-logs-endpoint"

--- a/tracing/axum-logs-endpoint/src/logger.rs
+++ b/tracing/axum-logs-endpoint/src/logger.rs
@@ -1,0 +1,48 @@
+use lazy_static::lazy_static;
+use serde_json::Value as JsonValue;
+use std::{io, sync::Mutex};
+use tokio::sync::broadcast;
+use tracing::metadata::LevelFilter;
+use tracing_subscriber::Layer;
+
+lazy_static! {
+    pub static ref LOG_CHANNEL: broadcast::Sender<JsonValue> = broadcast::channel(64).0;
+}
+
+pub struct Logger {
+    tx: broadcast::Sender<JsonValue>,
+}
+
+impl Logger {
+    pub fn new() -> Self {
+        Self {
+            tx: LOG_CHANNEL.clone(),
+        }
+    }
+
+    pub fn make_layer() -> impl Layer<shuttle_runtime::Registry> {
+        tracing_subscriber::fmt::layer()
+            .pretty()
+            .json()
+            .with_writer(Mutex::new(Self::new()))
+            .with_filter(LevelFilter::INFO)
+    }
+}
+
+impl io::Write for Logger {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let Ok(log) = serde_json::from_slice(buf) else {
+            return Ok(0);
+        };
+
+        if let Ok(n) = self.tx.send(log) {
+            return Ok(n);
+        }
+
+        Ok(0)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}

--- a/tracing/axum-logs-endpoint/src/main.rs
+++ b/tracing/axum-logs-endpoint/src/main.rs
@@ -5,7 +5,6 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-
 use axum_error::Result;
 use serde_json::Value as JsonValue;
 use shuttle_axum::ShuttleAxum;
@@ -29,11 +28,13 @@ async fn axum_logs() -> ShuttleAxum {
     Ok(router.into())
 }
 
+// Creates a tracing log with `message`
 async fn send_message(Path(message): Path<String>) -> String {
     info!(?message, now = ?SystemTime::now());
     message
 }
 
+// Waits for `amount` log lines to arrive in the channel and returns them
 async fn get_logs(
     Path(amount): Path<usize>,
     State(state): State<Arc<AppState>>,

--- a/tracing/axum-logs-endpoint/src/main.rs
+++ b/tracing/axum-logs-endpoint/src/main.rs
@@ -1,0 +1,53 @@
+use std::{sync::Arc, time::SystemTime};
+
+use axum::{
+    extract::{Path, State},
+    routing::{get, post},
+    Json, Router,
+};
+
+use axum_error::Result;
+use serde_json::Value as JsonValue;
+use shuttle_axum::ShuttleAxum;
+use tracing::info;
+
+mod logger;
+use logger::Logger;
+
+mod state;
+use state::AppState;
+
+#[shuttle_runtime::main(tracing_layer = Logger::make_layer)]
+async fn axum_logs() -> ShuttleAxum {
+    let state = AppState::new();
+    let router = Router::new()
+        .route("/", get(|| async { "Hello, world!" }))
+        .route("/message/:message", post(send_message))
+        .route("/logs/:amount", get(get_logs))
+        .with_state(state);
+
+    Ok(router.into())
+}
+
+async fn send_message(Path(message): Path<String>) -> String {
+    info!(?message, now = ?SystemTime::now());
+    message
+}
+
+async fn get_logs(
+    Path(amount): Path<usize>,
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<Vec<JsonValue>>> {
+    let mut rx = state.sub();
+    let mut logs = Vec::new();
+
+    while let Ok(log) = rx.recv().await {
+        logs.push(log);
+
+        if logs.len() == amount {
+            break;
+        }
+    }
+
+    Ok(Json(logs))
+}

--- a/tracing/axum-logs-endpoint/src/state.rs
+++ b/tracing/axum-logs-endpoint/src/state.rs
@@ -1,0 +1,21 @@
+use crate::logger::LOG_CHANNEL;
+use serde_json::Value as JsonValue;
+use std::sync::Arc;
+use tokio::sync::broadcast;
+
+#[derive(Debug)]
+pub struct AppState {
+    logs: broadcast::Sender<JsonValue>,
+}
+
+impl AppState {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            logs: LOG_CHANNEL.clone(),
+        })
+    }
+
+    pub fn sub(&self) -> broadcast::Receiver<JsonValue> {
+        self.logs.subscribe()
+    }
+}

--- a/tracing/custom-layer/Cargo.toml
+++ b/tracing/custom-layer/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "custom-tracing-layer"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tracing = "0.1.37"
+tracing-subscriber = "0.3.17"
+tokio = "1.28.2"
+
+# shuttle-runtime = "0.18.0"
+shuttle-runtime = { path = "../../../../shuttle.git/custom-tracing-layer/runtime" }
+lazy_static = "1.4.0"

--- a/tracing/custom-layer/Cargo.toml
+++ b/tracing/custom-layer/Cargo.toml
@@ -8,6 +8,5 @@ tracing = "0.1.37"
 tracing-subscriber = "0.3.17"
 tokio = "1.28.2"
 
-# shuttle-runtime = "0.18.0"
 shuttle-runtime = { path = "../../../../shuttle.git/custom-tracing-layer/runtime" }
 lazy_static = "1.4.0"

--- a/tracing/custom-layer/Cargo.toml
+++ b/tracing/custom-layer/Cargo.toml
@@ -4,9 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+lazy_static = "1.4.0"
+shuttle-runtime = "0.23.0"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.17"
 tokio = "1.28.2"
-
-shuttle-runtime = { path = "../../../../shuttle.git/custom-tracing-layer/runtime" }
-lazy_static = "1.4.0"

--- a/tracing/custom-layer/Shuttle.toml
+++ b/tracing/custom-layer/Shuttle.toml
@@ -1,0 +1,1 @@
+name = "custom-tracing-layer-example"

--- a/tracing/custom-layer/src/main.rs
+++ b/tracing/custom-layer/src/main.rs
@@ -40,7 +40,7 @@ impl shuttle_runtime::Service for MyService {
 
         while let Ok(message) = self.logs.recv().await {
             // do something with your logs!
-            eprintln!("Got a new log!");
+            println!("Got a new log!");
             tokio::fs::write(Logger::LOG_FILE, message).await?;
         }
 

--- a/tracing/custom-layer/src/main.rs
+++ b/tracing/custom-layer/src/main.rs
@@ -1,0 +1,99 @@
+use lazy_static::lazy_static;
+use std::{net::SocketAddr, time::Duration};
+use tokio::sync::broadcast;
+use tracing::info;
+use tracing_subscriber::fmt::MakeWriter;
+
+lazy_static! {
+    /// Global channel for sending logs
+    pub static ref LOG_CHANNEL: broadcast::Sender<String> = broadcast::channel(64).0;
+}
+
+/// Logger struct passed to our custom tracing layer
+#[derive(Debug)]
+struct Logger {
+    sender: broadcast::Sender<String>,
+}
+
+// Necessary for [`MakeWriter`] impl
+impl std::io::Write for Logger {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let message = String::from_utf8_lossy(buf);
+
+        if let Err(err) = self.sender.send(message.to_string()) {
+            eprintln!("Failed to send message: {err:?}");
+            return Err(std::io::Error::new(std::io::ErrorKind::Other, err));
+        }
+
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+// Necessary for passing [`Logger`] as a custom writer to [`tracing_subscriber`]
+impl MakeWriter<'_> for Logger {
+    type Writer = Self;
+
+    fn make_writer(&self) -> Self::Writer {
+        Self {
+            sender: LOG_CHANNEL.clone(),
+        }
+    }
+}
+
+impl Logger {
+    pub fn init<S>() -> impl tracing_subscriber::Layer<S>
+    where
+        S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+    {
+        let logger = Self {
+            sender: LOG_CHANNEL.clone(),
+        };
+
+        tracing_subscriber::fmt::layer()
+            .without_time()
+            .with_writer(logger)
+    }
+}
+
+#[derive(Debug)]
+struct MyService {
+    pub logs: broadcast::Receiver<String>,
+}
+
+impl MyService {
+    pub fn new() -> Self {
+        Self {
+            logs: LOG_CHANNEL.subscribe(),
+        }
+    }
+}
+
+#[shuttle_runtime::async_trait]
+impl shuttle_runtime::Service for MyService {
+    async fn bind(mut self, _addr: SocketAddr) -> Result<(), shuttle_runtime::Error> {
+        // send some messages...
+        for i in 0..10 {
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_secs(i)).await;
+                info!("Hello from thread #{i}!");
+            });
+        }
+
+        while let Ok(message) = self.logs.recv().await {
+            // do something with your logs!
+            eprintln!("Got a new log!");
+            eprintln!("\t{message}");
+        }
+
+        Ok(())
+    }
+}
+
+#[shuttle_runtime::main(tracing_layer = Logger::init)]
+async fn init() -> Result<MyService, shuttle_runtime::Error> {
+    Ok(MyService::new())
+}

--- a/tracing/custom-layer/src/main.rs
+++ b/tracing/custom-layer/src/main.rs
@@ -45,10 +45,7 @@ impl MakeWriter<'_> for Logger {
 }
 
 impl Logger {
-    pub fn init<S>() -> impl tracing_subscriber::Layer<S>
-    where
-        S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
-    {
+    pub fn init() -> impl tracing_subscriber::Layer<shuttle_runtime::Registry> {
         let logger = Self {
             sender: LOG_CHANNEL.clone(),
         };


### PR DESCRIPTION
In addition to [this new feature](https://github.com/shuttle-hq/shuttle/pull/1027) I also created these two examples to show off how to use it. The `axum-logs-endpoint` example exsits for testing purposes as requested.