### PR TITLE
feat: rocket static files with rocket config

### DIFF
--- a/rocket/dyn-templates/Rocket.toml
+++ b/rocket/dyn-templates/Rocket.toml
@@ -1,0 +1,2 @@
+[default]
+template_dir = "templates"

--- a/rocket/dyn-templates/src/main.rs
+++ b/rocket/dyn-templates/src/main.rs
@@ -7,7 +7,7 @@ use rocket_dyn_templates::{context, Template};
 
 #[get("/")]
 fn index() -> Redirect {
-    Redirect::to(uri!("/", hello(name = "Your Name")))
+    Redirect::to(uri!("/", hello(name = "your-name")))
 }
 #[get("/hello/<name>")]
 pub fn hello(name: &str) -> Template {
@@ -23,13 +23,7 @@ pub fn hello(name: &str) -> Template {
 
 #[shuttle_runtime::main]
 async fn rocket() -> shuttle_rocket::ShuttleRocket {
-    // Note that shuttle does not include Rocket.toml
-    // so merging config is the preferred way to modify any settings
-    // that would otherwise be set in Rocket.toml
-
-    let template_dir = "templates";
-    let figment = rocket::Config::figment().merge(("template_dir", template_dir));
-    let rocket = rocket::custom(figment)
+    let rocket = rocket::build()
         // If you also wish to serve static content, uncomment line below and corresponding 'use' on line 4
         // .mount("/", FileServer::from(relative!("templates")))
         .mount("/", routes![index, hello])

--- a/rocket/dyn-templates/templates/index.html.hbs
+++ b/rocket/dyn-templates/templates/index.html.hbs
@@ -6,7 +6,7 @@
 <body>
 <section id="hello">
     <h1>Hi {{ name }}!</h1>
-    <p>Try entering your own name in the page url to see the page content change <a href="./your_name">./hello/edit_this_part_of_url</a></p>
+    <p>Try entering your own name in the page url to see the page content change <a href="./your-name">./hello/edit_this_part_of_url</a></p>
     <h3>Here are the items supplied by the vec! macro in the Template::render context:</h3>
     <ul>
         {{#each items}}


### PR DESCRIPTION
Thanks to https://github.com/shuttle-hq/shuttle/pull/1050 we can now use `Rocket.toml` to configure rocket static assets directory, which is the convenctional way to do it.