### PR TITLE
bug: revert turso version update

### DIFF
--- a/axum/turso/Cargo.toml
+++ b/axum/turso/Cargo.toml
@@ -8,7 +8,7 @@ axum = { version = "0.6.18" }
 shuttle-axum = { version = "0.30.0" }
 shuttle-runtime = { version = "0.30.0" }
 shuttle-turso = { version = "0.30.0" }
-libsql-client = "0.32.0"
+libsql-client = "0.31.0"
 tokio = { version = "1.26.0" }
 serde = { version = "1.0.164", features = ["derive"] }
 serde_json = "1.0.99"


### PR DESCRIPTION
<!--
NOTE:
    Please target the branch `develop` for changes that are going to be
    released in the next release (usually breaking changes).
    Hotfixes and other non-breaking changes can target the `main` branch.
-->
## Description of change
Reverts the Turso library update. See shuttle-hq/shuttle#1355


## How has this been tested? (if applicable)
Using the local runner.

