### PR TITLE
chore: bump salvo

### DIFF
--- a/salvo/hello-world/Cargo.toml
+++ b/salvo/hello-world/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-salvo = "0.41.0"
+salvo = "0.63.0"
 shuttle-salvo = "0.35.0"
 shuttle-runtime = "0.35.0"
 tokio = "1.26.0"


### PR DESCRIPTION
## Description of change
Upgrades [salvo](https://github.com/salvo-rs/salvo) version for its example. Should only be merged after [shuttle#1486](https://github.com/shuttle-hq/shuttle/pull/1486) is released. Keeping this as draft because if merged right now, it will break the example.

<!-- Please write a summary of your changes and why you made them. -->
Once the shuttle-salvo is upgraded, this test may break after the shuttle version bump  

<!-- Be sure to reference any related issues by adding `Closes #`. -->

## How has this been tested? (if applicable)
Local tested only as it's not possible to deploy with current Salvo version


