### PR TITLE
chore: remove develop branch suggestion from pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,3 @@
-<!--
-NOTE:
-    Please target the branch `develop` for changes that are going to be
-    released in the next release (usually breaking changes).
-    Hotfixes and other non-breaking changes can target the `main` branch.
--->
 ## Description of change
 <!-- Please write a summary of your changes and why you made them. -->
 <!-- Be sure to reference any related issues by adding `Closes #`. -->


### PR DESCRIPTION
<!--
NOTE:
    Please target the branch `develop` for changes that are going to be
    released in the next release (usually breaking changes).
    Hotfixes and other non-breaking changes can target the `main` branch.
-->
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

We no longer actively use the develop branch, when the need arises to test several PRs together without merging to main, we can rather create a short-lived feature branch.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->


