### PR TITLE
chore: update poem to 2.0.0, shuttle-poem to 0.37.0

### DIFF
--- a/poem/hello-world/Cargo.toml
+++ b/poem/hello-world/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-poem = "1.3.55"
-shuttle-poem = "0.36.0"
+poem = "2.0.0"
+shuttle-poem = "0.37.0"
 shuttle-runtime = "0.36.0"
 tokio = "1.26.0"

--- a/poem/mongodb/Cargo.toml
+++ b/poem/mongodb/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 mongodb = "2.4.0"
-poem = "1.3.55"
-shuttle-poem = "0.36.0"
+poem = "2.0.0"
+shuttle-poem = "0.37.0"
 shuttle-shared-db = { version = "0.36.0", features = ["mongodb"] }
 shuttle-runtime = "0.36.0"
 serde = { version = "1.0.148", features = ["derive"] }

--- a/poem/postgres/Cargo.toml
+++ b/poem/postgres/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-poem = "1.3.55"
+poem = "2.0.0"
 serde = "1.0.148"
-shuttle-poem = "0.36.0"
+shuttle-poem = "0.37.0"
 shuttle-runtime = "0.36.0"
 shuttle-shared-db = { version = "0.36.0", features = ["postgres"] }
 sqlx = { version = "0.7.1", features = ["runtime-tokio-native-tls", "postgres"] }


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

As requested here: https://github.com/shuttle-hq/shuttle/pull/1520#pullrequestreview-1824881414

CI checks are expected to fail until shuttle-poem 0.37.0 is released.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->


