### PR TITLE
Add --idle-minutes 0 and restart command in package.json

### DIFF
--- a/fullstack-templates/saas/package.json
+++ b/fullstack-templates/saas/package.json
@@ -9,7 +9,8 @@
     "build": "next build && cargo build",
     "shuttle-login": "cargo shuttle login",
     "full": "cargo shuttle run --port 8001",
-    "start": "cargo shuttle project start",
+    "start": "cargo shuttle project start --idle-minutes 0",
+    "restart": "cargo shuttle project restart --idle-minutes 0",
     "stop": "cargo shuttle project stop",
     "deploy": "npm run build && cargo shuttle deploy --allow-dirty",
     "lint": "next lint"


### PR DESCRIPTION
To address user-reported crash issues, as discussed in the Discord thread [https://discord.com/channels/803236282088161321/1203990888041160804/1203991607268089887], I've appended --idle-minutes 0 to the start command in package.json. This addition is aimed at preventing idle-induced crashes. Additionally, I've introduced a restart command with the same --idle-minutes 0 parameter to further enhance application reliability and user experience.

## How has this been tested? (if applicable)
All information has been confirmed in the Discord by users
