### PR TITLE
fix: replace deprecated fn call in example `rocket/jwt-authentication`

### DIFF
--- a/rocket/jwt-authentication/src/claims.rs
+++ b/rocket/jwt-authentication/src/claims.rs
@@ -18,7 +18,8 @@ const SECRET: &str = "secret";
 
 lazy_static! {
     /// Time before token expires (aka exp claim)
-    static ref TOKEN_EXPIRATION: Duration = Duration::minutes(5);
+    static ref TOKEN_EXPIRATION: Duration = Duration::try_minutes(5)
+        .expect("failed to create an expiration duration");
 }
 
 // Used when decoding a token to `Claims`


### PR DESCRIPTION
## Description of change

`chrono::TimeDelta::minutes` to `chrono::TimeDelta::try_minutes`, with `.expect`

https://github.com/shuttle-hq/shuttle-examples/blob/c92718eabe34da02f320df45eb2abd75980e9ada/rocket/jwt-authentication/src/claims.rs#L21

## How has this been tested? (if applicable)

CI run on fork: https://github.com/supleed2/shuttle-examples/actions/runs/8187671386