### PR TITLE
fix: Add shell true to turbowatch in `fullstack-templates/saas`

### DIFF
--- a/fullstack-templates/saas/turbowatch.ts
+++ b/fullstack-templates/saas/turbowatch.ts
@@ -15,6 +15,7 @@ function executeCommand(command: string | string[], abortSignal?: AbortSignal): 
         process = spawn(cmd, args, {
             cwd: __dirname,
             stdio: 'inherit',
+            shell: true,
         });
 
         // When the process exits, resolve or reject the promise


### PR DESCRIPTION
## Description of change
This MR introduces the `{ shell: true }` option to the spawn command in [`turbowatch.ts`](https://github.com/shuttle-hq/shuttle-examples/blob/c20e19e908a0d327bf33603164247e621b4b1e2a/fullstack-templates/saas/turbowatch.ts#L15-L18) for the [`fullstack-templates/saas`](https://github.com/shuttle-hq/shuttle-examples/tree/main/fullstack-templates/saas) template.

Please see #175 for further details.

Closes #175 

## How has this been tested? (if applicable)
1. `cargo shuttle init`
2. Select the [`fullstack-templates/saas`](https://github.com/shuttle-hq/shuttle-examples/tree/main/fullstack-templates/saas) template
3. `npm install`
4. `npm run dev`

I observed the front-end to successfully build, instead of throwing `EINVAL`.


