### PR TITLE
improvement: bump sqlx to 0.8 in database examples

### DIFF
--- a/actix-web/postgres/Cargo.toml
+++ b/actix-web/postgres/Cargo.toml
@@ -9,5 +9,5 @@ shuttle-actix-web = "0.47.0"
 shuttle-runtime = "0.47.0"
 serde = "1.0.148"
 shuttle-shared-db = { version = "0.47.0", features = ["postgres", "sqlx"] }
-sqlx = "0.7.1"
+sqlx = "0.8.0"
 tokio = "1.26.0"

--- a/axum/htmx-crud/Cargo.toml
+++ b/axum/htmx-crud/Cargo.toml
@@ -12,6 +12,6 @@ serde_json = "1.0.107"
 shuttle-axum = "0.47.0"
 shuttle-runtime = "0.47.0"
 shuttle-shared-db = { version = "0.47.0", features = ["postgres", "sqlx"] }
-sqlx = "0.7.2"
+sqlx = "0.8.0"
 tokio = "1.28.2"
 tokio-stream = { version = "0.1.14", features = ["sync"] }

--- a/axum/oauth2/Cargo.toml
+++ b/axum/oauth2/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1.0.183", features = ["derive"] }
 shuttle-axum = "0.47.0"
 shuttle-runtime = "0.47.0"
 shuttle-shared-db = { version = "0.47.0", features = ["postgres", "sqlx"] }
-sqlx = "0.8.0"
+sqlx = { version = "0.8.0", features = ["macros", "chrono"] }
 thiserror = "1.0.57"
 time = "0.3.25"
 tokio = "1.28.2"

--- a/axum/oauth2/Cargo.toml
+++ b/axum/oauth2/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1.0.183", features = ["derive"] }
 shuttle-axum = "0.47.0"
 shuttle-runtime = "0.47.0"
 shuttle-shared-db = { version = "0.47.0", features = ["postgres", "sqlx"] }
-sqlx = { version = "0.7.2", features = ["runtime-tokio-rustls", "macros", "chrono"] }
+sqlx = "0.8.0"
 thiserror = "1.0.57"
 time = "0.3.25"
 tokio = "1.28.2"

--- a/axum/postgres/Cargo.toml
+++ b/axum/postgres/Cargo.toml
@@ -9,5 +9,5 @@ serde = { version = "1.0.188", features = ["derive"] }
 shuttle-axum = "0.47.0"
 shuttle-runtime = "0.47.0"
 shuttle-shared-db = { version = "0.47.0", features = ["postgres", "sqlx"] }
-sqlx = "0.7.1"
+sqlx = "0.8.0"
 tokio = "1.28.2"

--- a/fullstack-templates/saas/backend/Cargo.toml
+++ b/fullstack-templates/saas/backend/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0.160", features = ["derive"] }
 shuttle-axum = "0.47.0"
 shuttle-runtime = "0.47.0"
 shuttle-shared-db = { version = "0.47.0", features = ["postgres", "sqlx"] }
-sqlx = { version = "0.7.1", features = ["time"] }
+sqlx = { version = "0.8.0", features = ["time"] }
 time = { version = "0.3.20", features = ["serde"] }
 tokio = "1.27.0"
 tower = "0.4.13"

--- a/rocket/postgres/Cargo.toml
+++ b/rocket/postgres/Cargo.toml
@@ -9,5 +9,5 @@ serde = "1.0.148"
 shuttle-rocket = "0.47.0"
 shuttle-runtime = "0.47.0"
 shuttle-shared-db = { version = "0.47.0", features = ["postgres", "sqlx"] }
-sqlx = "0.7.1"
+sqlx = "0.8.0"
 tokio = "1.26.0"

--- a/rocket/url-shortener/Cargo.toml
+++ b/rocket/url-shortener/Cargo.toml
@@ -10,6 +10,6 @@ serde = "1.0.148"
 shuttle-rocket = "0.47.0"
 shuttle-runtime = "0.47.0"
 shuttle-shared-db = { version = "0.47.0", features = ["postgres", "sqlx"] }
-sqlx = "0.7.1"
+sqlx = "0.8.0"
 tokio = "1.26.0"
 url = "2.3.1"

--- a/serenity/postgres/Cargo.toml
+++ b/serenity/postgres/Cargo.toml
@@ -10,6 +10,6 @@ serenity = { version = "0.12.0", default-features = false, features = ["client",
 shuttle-runtime = "0.47.0"
 shuttle-serenity = "0.47.0"
 shuttle-shared-db = { version = "0.47.0", features = ["postgres", "sqlx"] }
-sqlx = "0.7.1"
+sqlx = "0.8.0"
 tokio = "1.26.0"
 tracing = "0.1.37"

--- a/shuttle-cron/Cargo.toml
+++ b/shuttle-cron/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 apalis = { version = "0.4.9", features = ["cron", "postgres", "extensions", "retry"] }
 chrono = { version = "0.4.32", features = ["clock", "serde"] }
 serde = { version = "1.0.195", features = ["derive"] }
-shuttle-runtime = "0.37.0"
-shuttle-shared-db = { version = "0.37.0", features = ["postgres"] }
+shuttle-runtime = "0.47.0"
+shuttle-shared-db = { version = "0.47.0", features = ["postgres"] }
 sqlx = { version = "0.8.0", features = ["runtime-tokio-native-tls", "postgres"] }
 tokio = "1"
 tower = { version = "0.4.13" }

--- a/shuttle-cron/Cargo.toml
+++ b/shuttle-cron/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 apalis = { version = "0.4.9", features = ["cron", "postgres", "extensions", "retry"] }
 chrono = { version = "0.4.32", features = ["clock", "serde"] }
 serde = { version = "1.0.195", features = ["derive"] }
-shuttle-runtime = "0.47.0"
-shuttle-shared-db = { version = "0.47.0", features = ["postgres"] }
-sqlx = { version = "0.8.0", features = ["runtime-tokio-native-tls", "postgres"] }
+shuttle-runtime = "0.46.0"
+shuttle-shared-db = { version = "0.46.0", features = ["postgres"] }
+sqlx = { version = "0.7.1", features = ["runtime-tokio-native-tls", "postgres"] }
 tokio = "1"
 tower = { version = "0.4.13" }

--- a/shuttle-cron/Cargo.toml
+++ b/shuttle-cron/Cargo.toml
@@ -10,6 +10,6 @@ chrono = { version = "0.4.32", features = ["clock", "serde"] }
 serde = { version = "1.0.195", features = ["derive"] }
 shuttle-runtime = "0.37.0"
 shuttle-shared-db = { version = "0.37.0", features = ["postgres"] }
-sqlx = { version = "0.7.3", features = ["runtime-tokio-native-tls", "postgres"] }
+sqlx = { version = "0.8.0", features = ["runtime-tokio-native-tls", "postgres"] }
 tokio = "1"
 tower = { version = "0.4.13" }


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

- this is a matching PR to #1838 submitted for the main Shuttle repo
- bumps sqlx to 0.8 in all database examples

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

- have not done any testing
- I believe that the PR for #1838 in the main repo must be accepted first
