### PR TITLE
improvement: update libsql to 0.6.0  in Axum Turso example

### DIFF
--- a/axum/turso/Cargo.toml
+++ b/axum/turso/Cargo.toml
@@ -8,7 +8,7 @@ axum = "0.7.3"
 shuttle-axum = "0.49.0"
 shuttle-runtime = "0.49.0"
 shuttle-turso = "0.49.0"
-libsql = "0.3.1"
+libsql = "0.6.0"
 tokio = "1.26.0"
 serde = { version = "1.0.164", features = ["derive"] }
 serde_json = "1.0.99"


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Bumped libsql to 0.6.0 in the Axum Turso example, to coincide with the associated PR in the main Shuttle repo.


## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

I didn't run any tests.
