### PR TITLE
rocket: Include Rocket.toml in build assets

### DIFF
--- a/rocket/dyn-templates/Shuttle.toml
+++ b/rocket/dyn-templates/Shuttle.toml
@@ -1,4 +1,5 @@
 [build]
 assets = [
+    "Rocket.toml",
     "templates",
 ]


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->
This PR includes a fix.

Rocket.toml is added in assets list of Shuttle.toml.


## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->
`shuttle deploy` fails, if templates/ folder is renamed, as Rocket.toml is never read (by default rocket will look in folder named templates/, that's why rename is needed for this test).
With this change, Rocket.toml is read and project is deployed correctly.

